### PR TITLE
Corrected relative paths in TCL scripts

### DIFF
--- a/hw/scripts/varium_c1100_xdma_gen4_x1_custom.tcl
+++ b/hw/scripts/varium_c1100_xdma_gen4_x1_custom.tcl
@@ -1,6 +1,8 @@
 create_project varium_c1100_xdma_gen4_x1_custom ./varium_c1100_xdma_gen4_x1_custom -part xcu55n-fsvh2892-2l-e
 
-add_files -fileset constrs_1 [ glob ../hw/src/varium_c1100/xdma_gen4_x1_minimal/*.xdc ]
+set script_dir [ file dirname [ file normalize [ info script ] ] ]
 
-source ../hw/src/varium_c1100/xdma_gen4_x1_minimal/shell.tcl
+add_files -fileset constrs_1 [ glob $script_dir/../src/varium_c1100/xdma_gen4_x1_minimal/*.xdc ]
+
+source $script_dir/../src/varium_c1100/xdma_gen4_x1_minimal/shell.tcl
 make_wrapper -top -import -files [get_files shell.bd]

--- a/hw/scripts/varium_c1100_xdma_gen4_x1_minimal.tcl
+++ b/hw/scripts/varium_c1100_xdma_gen4_x1_minimal.tcl
@@ -1,8 +1,10 @@
 create_project -in_memory -part xcu55n-fsvh2892-2l-e
 
-read_xdc [ glob ../hw/src/varium_c1100/xdma_gen4_x1_minimal/*.xdc ]
+set script_dir [ file dirname [ file normalize [ info script ] ] ]
 
-source ../hw/src/varium_c1100/xdma_gen4_x1_minimal/shell.tcl
+read_xdc [ glob $script_dir/../src/varium_c1100/xdma_gen4_x1_minimal/*.xdc ]
+
+source $script_dir/../src/varium_c1100/xdma_gen4_x1_minimal/shell.tcl
 make_wrapper -top -import -files [get_files shell.bd]
 generate_target all [get_files shell.bd]
 

--- a/hw/scripts/varium_c1100_xdma_gen4_x8_custom.tcl
+++ b/hw/scripts/varium_c1100_xdma_gen4_x8_custom.tcl
@@ -1,6 +1,8 @@
 create_project varium_c1100_xdma_gen4_x8_custom ./varium_c1100_xdma_gen4_x8_custom -part xcu55n-fsvh2892-2l-e
 
-add_files -fileset constrs_1 [ glob ../hw/src/varium_c1100/xdma_gen4_x8_minimal/*.xdc ]
+set script_dir [ file dirname [ file normalize [ info script ] ] ]
 
-source ../hw/src/varium_c1100/xdma_gen4_x8_minimal/shell.tcl
+add_files -fileset constrs_1 [ glob $script_dir/../src/varium_c1100/xdma_gen4_x8_minimal/*.xdc ]
+
+source $script_dir/../src/varium_c1100/xdma_gen4_x8_minimal/shell.tcl
 make_wrapper -top -import -files [get_files shell.bd]

--- a/hw/scripts/varium_c1100_xdma_gen4_x8_minimal.tcl
+++ b/hw/scripts/varium_c1100_xdma_gen4_x8_minimal.tcl
@@ -1,8 +1,10 @@
 create_project -in_memory -part xcu55n-fsvh2892-2l-e
 
-read_xdc [ glob ../hw/src/varium_c1100/xdma_gen4_x8_minimal/*.xdc ]
+set script_dir [ file dirname [ file normalize [ info script ] ] ]
 
-source ../hw/src/varium_c1100/xdma_gen4_x8_minimal/shell.tcl
+read_xdc [ glob $script_dir/../src/varium_c1100/xdma_gen4_x8_minimal/*.xdc ]
+
+source $script_dir/../src/varium_c1100/xdma_gen4_x8_minimal/shell.tcl
 make_wrapper -top -import -files [get_files shell.bd]
 generate_target all [get_files shell.bd]
 


### PR DESCRIPTION
Relative paths within TCL scripts are always relative to the main script, which breaks if the main script is an unexpected location. Getting the directory of a callee script fixes that.